### PR TITLE
Git checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,12 +126,6 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
@@ -262,31 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd8ef63a44e821956c6a276eca0faaa889d6a067dfcdbd5bfe85dce3a1d250"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "lazy_static",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "dashmap"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,22 +342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,7 +383,6 @@ dependencies = [
  "clap",
  "git2",
  "tokei",
- "tui",
  "url",
 ]
 
@@ -537,24 +483,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -693,48 +621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mio"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
-dependencies = [
- "cfg-if",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1017,33 +903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
-dependencies = [
- "libc",
- "mio",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-dependencies = [
- "arc-swap",
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
 name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,21 +999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7de74b91c6cb83119a2140e7c215d95d9e54db27b58a500a2cbdeec4987b0a2"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm",
- "either",
- "itertools",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,12 +1027,6 @@ checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
@@ -1284,13 +1122,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2018"
 clap = "2.33.0"
 tokei = "11.1.0"
 git2 = "0.13.5"
-tui = { version = "0.9.1", features = ["crossterm"], default-features = false }
 url = "2.1.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,14 @@ pub enum Error {
     ///
     /// Error occurs from calling `GitDetective::clone()`
     GitUrlError(url::ParseError),
+    /// Repository isn't in a clean state
+    ///
+    /// Returned from `Repo::is_clean`
+    UncleanState(git2::RepositoryState),
+    /// Git String is not valid UTF-8
+    ///
+    /// Could be a Branch name, commit hash, etc
+    NonUTF8String,
 }
 
 impl From<git2::Error> for Error {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -112,7 +112,7 @@ impl Repo {
 
     /// List Contributors
     ///
-    /// NOTE: If author name isn't valid UTF-8 they will be filtered out
+    /// **NOTE**: If author name isn't valid UTF-8 they will be filtered out
     ///
     /// # Example
     ///
@@ -152,7 +152,7 @@ impl Repo {
 
     /// List tags
     ///
-    /// NOTE: If a Tag has a name that isn't valid UTF-8 it is filtered out
+    /// **NOTE**: If a Tag has a name that isn't valid UTF-8 it is filtered out
     ///
     /// # Parameters
     ///

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -368,4 +368,77 @@ mod git_tests {
         let removed = remove_dir_all(path);
         assert!(removed.is_ok());
     }
+
+    #[test]
+    fn checkout_tag() {
+        let path = PathBuf::from("cursive");
+        let clone = Repo::clone("https://github.com/gyscos/cursive.git", &path);
+        assert!(clone.is_ok());
+        let repo = clone.unwrap();
+        let tags_result = repo.tags(Some("v0.14.0"));
+        assert!(tags_result.is_ok());
+        let tags = tags_result.unwrap();
+        assert_eq!(tags.len(), 1);
+        let checkout_result = repo.checkout(&tags[0]);
+        assert!(checkout_result.is_ok());
+        let removed = remove_dir_all(path);
+        assert!(removed.is_ok());
+    }
+
+    #[test]
+    fn checkout_commit() {
+        let path = PathBuf::from("awesome-rust");
+        let clone = Repo::clone("https://github.com/rust-unofficial/awesome-rust.git", &path);
+        assert!(clone.is_ok());
+        let repo = clone.unwrap();
+        let commits_result = repo.commits();
+        assert!(commits_result.is_ok());
+        let mut commits = commits_result.unwrap();
+        let commit_option =
+            commits.find(|c| c.name().unwrap() == "bc7268a41e6cf7cc5391b1fbfec8f1394c5d88b6");
+        assert!(commit_option.is_some());
+        let commit = commit_option.unwrap();
+        let checkout_result = repo.checkout(&commit);
+        assert!(checkout_result.is_ok());
+        let removed = remove_dir_all(path);
+        assert!(removed.is_ok());
+    }
+
+    #[test]
+    fn checkout_branch() {
+        let path = PathBuf::from("rust-book");
+        let clone = Repo::clone("https://github.com/rust-lang/book.git", &path);
+        assert!(clone.is_ok());
+        let repo = clone.unwrap();
+        let branches_result = repo.branches(Some(git2::BranchType::Remote));
+        assert!(branches_result.is_ok());
+        let mut branches = branches_result.unwrap();
+        let branch_option = branches.find(|c| c.name().unwrap() == "origin/gh-pages");
+        assert!(branch_option.is_some());
+        let branch = branch_option.unwrap();
+        let checkout_result = repo.checkout(&branch);
+        assert!(checkout_result.is_ok());
+        let removed = remove_dir_all(path);
+        assert!(removed.is_ok());
+    }
+
+    #[test]
+    fn checkout_tag_then_different_tag() {
+        let path = PathBuf::from("spotify-tui");
+        let clone = Repo::clone("https://github.com/Rigellute/spotify-tui.git", &path);
+        assert!(clone.is_ok());
+        let repo = clone.unwrap();
+        let tags_result = repo.tags(Some("v0.10.0"));
+        assert!(tags_result.is_ok());
+        let tags = tags_result.unwrap();
+        assert_eq!(tags.len(), 1);
+        let checkout_result = repo.checkout(&tags[0]);
+        assert!(checkout_result.is_ok());
+        let tags_result = repo.tags(Some("v0.9.0"));
+        assert!(tags_result.is_ok());
+        let tags = tags_result.unwrap();
+        assert_eq!(tags.len(), 1);
+        let checkout_result = repo.checkout(&tags[0]);
+        assert!(checkout_result.is_ok());
+    }
 }


### PR DESCRIPTION
## Changes
- Removed dependency `tui` postponing the decision on which terminal library to use. Debating between [tui-rs](https://github.com/fdehau/tui-rs) and [cursive](https://github.com/gyscos/cursive)
- Added checkout for `Tag`, `Commit`, and `Branch`
- Added Tests for checkout

**NOTE**: Checkout detaches the `HEAD` of the repository