### PR TITLE
Diff stats

### DIFF
--- a/src/diff_stats.rs
+++ b/src/diff_stats.rs
@@ -1,0 +1,18 @@
+use std::ops::AddAssign;
+
+/// TODO: docs
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct DiffStats {
+    /// Lines of code inserted
+    pub insertions: usize,
+    /// Lines of code deleted
+    pub deletions: usize,
+}
+
+#[doc(hidden)]
+impl AddAssign<git2::DiffStats> for DiffStats {
+    fn add_assign(&mut self, other: git2::DiffStats) {
+        self.insertions += other.insertions();
+        self.deletions += other.deletions();
+    }
+}

--- a/src/diff_stats.rs
+++ b/src/diff_stats.rs
@@ -1,6 +1,23 @@
 use std::ops::AddAssign;
 
-/// TODO: docs
+/// Insertion and Deletion statistics for Commit diffs
+///
+/// # Example
+///
+/// ```
+/// # use git_detective::Error;
+/// use git_detective::GitDetective;
+///
+/// # fn main() -> Result<(), Error> {
+/// let mut gd = GitDetective::open(".")?;
+/// let diff_stats = gd.diff_stats()?;
+/// for (author, diff_stat) in diff_stats {
+///   println!("{}: +{} -{}", author, diff_stat.insertions, diff_stat.deletions);
+/// }
+///
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct DiffStats {
     /// Lines of code inserted

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -1,5 +1,7 @@
 use std::string::FromUtf8Error;
 
+use chrono::{DateTime, NaiveDateTime, Utc};
+
 use crate::error::Error;
 use crate::git::GitReference;
 use crate::Signature;
@@ -66,6 +68,13 @@ impl<'repo> Commit<'_> {
     /// Get the [`Oid`](https://docs.rs/git2/latest/git2/struct.Oid.html) of a `Commit`
     pub fn id(&self) -> git2::Oid {
         self.inner.id()
+    }
+
+    /// Date commited
+    pub fn date(&self) -> DateTime<Utc> {
+        let timestamp = self.inner.time().seconds();
+        let naive = NaiveDateTime::from_timestamp(timestamp, 0);
+        DateTime::<Utc>::from_utc(naive, Utc)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl GitDetective {
             .map(|(branch, _)| Branch::from(branch)))
     }
 
-    /// All commits for Repository
+    /// All commits for Repository that are parents of `HEAD` in **reverse** order
     ///
     /// # Example
     ///
@@ -485,13 +485,13 @@ impl GitDetective {
     /// use git_detective::GitDetective;
     ///
     /// # fn main() -> Result<(), Error> {
-    /// let mut repo = GitDetective::open(".")?;
-    /// let before_files = repo.ls()?;
+    /// let mut gd = GitDetective::open(".")?;
+    /// let before_files = gd.ls()?;
     ///
-    /// repo.exclude_file("README.md");
-    /// repo.exclude_file("Cargo.toml");
+    /// gd.exclude_file("README.md");
+    /// gd.exclude_file("Cargo.toml");
     ///
-    /// let mut after_files = repo.ls()?;
+    /// let mut after_files = gd.ls()?;
     /// assert!(after_files.iter().all(|file| &file.path != "README.md" && &file.path != "Cargo.toml"));
     /// # Ok(())
     /// # }

--- a/tests/git_detective.rs
+++ b/tests/git_detective.rs
@@ -278,4 +278,17 @@ mod git_detective_integration_tests {
         assert!(removed.is_ok());
         Ok(())
     }
+
+    #[test]
+    fn diff_stats() -> Result<(), Error> {
+        let gd = GitDetective::open(".")?;
+        let stats_map = gd.diff_stats()?;
+        assert!(stats_map.contains_key("Nick Hackman"));
+        assert!(stats_map.contains_key("NickHackman"));
+        assert!(
+            stats_map.get("Nick Hackman").unwrap().insertions
+                > stats_map.get("NickHackman").unwrap().insertions
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Added `GitDetective::diff_stats` - Method that calculate the `+` and `-` deltas like Github contributors page.

`GitDetective::commits` now is more explicit on the order and commits
that it returns. Changed variable naming in `GitDetective::exclude_file` to use
`gd` instead of `repo`.